### PR TITLE
feat: Implement custom popup and update link handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,6 +195,7 @@ flexibility(document.documentElement);
     </meta>
     </meta>
     <link href="styles.css" rel="stylesheet" />
+    <link rel="stylesheet" href="popup-styles.css">
   </head>
   <body class="wp-singular page-template page-template-elementor_header_footer page page-id-62967 wp-custom-logo wp-theme-astra theme-astra woocommerce-no-js woocommerce-multi-currency-EUR ast-desktop ast-page-builder-template ast-no-sidebar astra-4.5.2 group-blog ast-single-post ast-inherit-site-logo-transparent ast-hfb-header elementor-default elementor-template-full-width elementor-kit-5 elementor-page elementor-page-62967 astra-addon-4.6.5">
     <noscript>
@@ -428,7 +429,7 @@ flexibility(document.documentElement);
                       <div class="elementor-element elementor-element-ba390db elementor-widget-mobile__width-inherit elementor-align-justify elementor-widget elementor-widget-button" data-element_type="widget" data-id="ba390db" data-widget_type="button.default">
                         <div class="elementor-widget-container">
                           <div class="elementor-button-wrapper">
-                            <a class="elementor-button elementor-button-link elementor-size-sm" href="#elementor-action%3Aaction%3Dpopup%3Aopen%26settings%3DeyJpZCI6IjUzOTY1IiwidG9nZ2xlIjpmYWxzZX0%3D" target="_blank">
+                            <a class="elementor-button elementor-button-link elementor-size-sm open-popup" href="#">
                               <span class="elementor-button-content-wrapper">
                                 <span class="elementor-button-text">Apuntarse ahora</span>
                               </span>
@@ -1057,7 +1058,7 @@ flexibility(document.documentElement);
                   <div class="elementor-element elementor-element-65a782e elementor-widget-mobile__width-inherit elementor-align-justify elementor-widget elementor-widget-button" data-element_type="widget" data-id="65a782e" data-widget_type="button.default">
                     <div class="elementor-widget-container">
                       <div class="elementor-button-wrapper">
-                        <a class="elementor-button elementor-button-link elementor-size-sm" href="#elementor-action%3Aaction%3Dpopup%3Aopen%26settings%3DeyJpZCI6IjUzOTY1IiwidG9nZ2xlIjpmYWxzZX0%3D" target="_blank">
+                        <a class="elementor-button elementor-button-link elementor-size-sm open-popup" href="#">
                           <span class="elementor-button-content-wrapper">
                             <span class="elementor-button-text">Reservar plaza gratis para la clase</span>
                           </span>
@@ -1075,7 +1076,7 @@ flexibility(document.documentElement);
                     <div class="elementor-element elementor-element-0f9b825 elementor-widget-mobile__width-inherit elementor-align-justify elementor-widget elementor-widget-button" data-element_type="widget" data-id="0f9b825" data-widget_type="button.default">
                       <div class="elementor-widget-container">
                         <div class="elementor-button-wrapper">
-                          <a class="elementor-button elementor-button-link elementor-size-sm" href="#elementor-action%3Aaction%3Dpopup%3Aopen%26settings%3DeyJpZCI6IjUzOTY1IiwidG9nZ2xlIjpmYWxzZX0%3D" target="_blank">
+                          <a class="elementor-button elementor-button-link elementor-size-sm open-popup" href="#">
                             <span class="elementor-button-content-wrapper">
                               <span class="elementor-button-text">Apuntarse ahora</span>
                             </span>
@@ -1668,8 +1669,43 @@ flexibility(document.documentElement);
         /^[A-z0-9_-]+$/.test(e) && (t = document.getElementById(e)) && (/^(?:a|select|input|button|textarea)$/i.test(t.tagName) || (t.tabIndex = -1), t.focus())
       }, !1);
     </script>
+
+    <!-- Popup Modal -->
+    <div id="popup-modal" class="popup-overlay" style="display: none;">
+      <div class="popup-content">
+        <button class="popup-close" onclick="closePopup()">&times;</button>
+        <h2>⏳ Reserva tu plaza</h2>
+        <p>Asiste gratis a la clase más completa sobre Trading con IA.</p>
+        <form action="#" method="POST">
+          <div class="form-group">
+            <label for="nombre">Nombre</label>
+            <input type="text" id="nombre" name="nombre">
+          </div>
+          <div class="form-group">
+            <label for="telefono">Teléfono</label>
+            <div class="phone-input">
+              <select>
+                <option>Spain</option>
+              </select>
+              <input type="text" id="telefono" name="telefono" value="+34">
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="correo">Correo</label>
+            <input type="email" id="correo" name="correo">
+          </div>
+          <div class="form-group checkbox-group">
+            <input type="checkbox" id="terminos" name="terminos">
+            <label for="terminos">He leído y acepto los <a href="/terminos" target="_blank">términos</a> y la <a href="/politica-de-privacidad" target="_blank">política de privacidad</a>.*</label>
+          </div>
+          <button type="submit" class="submit-btn">Apuntarse gratis</button>
+        </form>
+      </div>
+    </div>
+
     <!-- Honeypot Bot Trap -->
     <a href="/bot-trap-detected" style="display:none;position:absolute;left:-9999px;">Admin Access</a>
+    <script src="popup-script.js"></script>
     <script crossorigin="anonymous" data-cf-beacon='{"rayId":"9801ce496b731d6c","serverTiming":{"name":{"cfExtPri":true,"cfEdge":true,"cfOrigin":true,"cfL4":true,"cfSpeedBrain":true,"cfCacheStatus":true}},"version":"2025.8.0","token":"5cf383d5aae9439184bd3a730882d254"}' defer="" integrity="sha512-ZpsOmlRQV6y907TI0dKBHq9Md29nnaEIPlkf84rnaERnq6zvWvPUqr2ft8M1aS28oN72PdrCzSjY4U6VaAw1EQ==" src="https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015"></script>
   </body>
 </html>

--- a/popup-script.js
+++ b/popup-script.js
@@ -1,0 +1,70 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const modal = document.getElementById('popup-modal');
+
+    function openPopup() {
+        if (modal) {
+            modal.style.display = 'flex';
+        }
+    }
+
+    function closePopup() {
+        if (modal) {
+            modal.style.display = 'none';
+        }
+    }
+
+    // Close popup when clicking on the close button or overlay
+    if (modal) {
+        modal.addEventListener('click', function(event) {
+            if (event.target === modal || event.target.classList.contains('popup-close')) {
+                closePopup();
+            }
+        });
+    }
+
+    // Assign closePopup to window to be accessible from inline onclick
+    window.closePopup = closePopup;
+
+    // "Cargar más" logic
+    let loadMoreCount = 0;
+    const maxLoads = 2;
+
+    document.body.addEventListener('click', function(event) {
+        const target = event.target;
+
+        // Find the closest ancestor link that is a popup trigger
+        const popupTrigger = target.closest('a.open-popup, a[href*="#elementor-action"]');
+
+        if (popupTrigger) {
+            // Exclude accordions which might also be links with similar patterns
+            if (popupTrigger.closest('.e-n-accordion-item')) {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopPropagation();
+            openPopup();
+            return; // Stop further processing for this click
+        }
+
+        // Handle "Cargar más" separately and specifically.
+        // This is speculative as the element is dynamically loaded.
+        const loadMoreTrigger = target.closest('a, button');
+        if (loadMoreTrigger && loadMoreTrigger.textContent.includes('Cargar más')) {
+            if (loadMoreCount >= maxLoads) {
+                event.preventDefault();
+                event.stopPropagation();
+                console.log('"Cargar más" disabled.');
+                // Disable the button to prevent further clicks
+                if(loadMoreTrigger.tagName === 'A') {
+                    loadMoreTrigger.style.pointerEvents = 'none';
+                }
+                loadMoreTrigger.style.opacity = '0.5';
+            } else {
+                loadMoreCount++;
+                console.log(`"Cargar más" clicked ${loadMoreCount} time(s).`);
+                // Allow the click to proceed for the first two times.
+            }
+        }
+    });
+});

--- a/popup-styles.css
+++ b/popup-styles.css
@@ -1,0 +1,78 @@
+.popup-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+.popup-content {
+  background-color: #fff;
+  padding: 30px;
+  border-radius: 10px;
+  width: 500px;
+  max-width: 90%;
+  position: relative;
+  text-align: center;
+}
+.popup-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+}
+.popup-content h2 {
+  font-size: 24px;
+  margin-bottom: 10px;
+}
+.popup-content p {
+  font-size: 16px;
+  margin-bottom: 20px;
+}
+.form-group {
+  margin-bottom: 15px;
+  text-align: left;
+}
+.form-group label {
+  display: block;
+  margin-bottom: 5px;
+  font-size: 14px;
+}
+.form-group input, .form-group select {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+}
+.phone-input {
+  display: flex;
+}
+.phone-input select {
+  width: 30%;
+  margin-right: 10px;
+}
+.checkbox-group {
+  display: flex;
+  align-items: center;
+}
+.checkbox-group input {
+  width: auto;
+  margin-right: 10px;
+}
+.submit-btn {
+  background-color: #e0007a;
+  color: #fff;
+  padding: 15px 30px;
+  border: none;
+  border-radius: 5px;
+  font-size: 18px;
+  cursor: pointer;
+  width: 100%;
+}


### PR DESCRIPTION
This commit introduces a new custom popup modal to replace the existing Elementor popups on the page.

Key changes include:
- A new popup modal has been added to `index.html`.
- The styling for the popup has been externalized to `popup-styles.css`, ensuring it is responsive and mobile-friendly.
- The JavaScript logic for the popup has been moved to `popup-script.js`.
- The script now uses event delegation to handle clicks on all links that previously triggered an Elementor popup, making the solution robust for both static and dynamically loaded content.
- Implemented logic to limit the 'Cargar más' functionality for reviews to two clicks, as requested.